### PR TITLE
bring in the exceptions module after refactor

### DIFF
--- a/src/SkillRunner/__init__.py
+++ b/src/SkillRunner/__init__.py
@@ -7,6 +7,7 @@ import os # used to block environ access
 import azure.functions as func
 
 from .bot import bot as _bot
+from .bot import exceptions
 
 
 def run_code(req, api_token):


### PR DESCRIPTION
During the refactor in #2, the custom exceptions module was moved to a subdirectory, breaking error reporting if the user's code had an exception. 

This brings the exceptions module back in so that the runner can report exceptions correctly. 