### PR TITLE
Fake the `os` module

### DIFF
--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -148,7 +148,7 @@ class Bot(object):
         Run the code the user has submitted.
         """
         try:
-            # Remove `os` from `sys` so users cannot use the module.
+            # Replace `os` with an instance of FakeOS so skills can't access the operating system.
             os_copy = os
             sys.modules['os'] = FakeOS()
 


### PR DESCRIPTION
It feels a little gross and weird, but this injects a fake `os` module into the Python script runner. Previously, we removed `os` so that skills would error if someone tried to import `os`. However, it turns out that some libraries use `os` to check environment variables etc, and will puke if it's not there. 

So... this creates a faked up object that returns `None` for any method calls to `os`. This shouldn't impact users since they shouldn't be interacting with the operating system anyways.