### PR TITLE
add nludb 0.1.4

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,6 +10,7 @@ ecdsa==0.14.1
 idna==2.10
 jmespath==0.10.0
 jsonpickle==2.0.0
+nludb==0.1.4
 numpy==1.19.4
 oauthlib==3.1.0
 octokitpy==0.15.0


### PR DESCRIPTION
Adds [nludb](https://nludb.com) 0.1.4. 

Ted from NLUDB is planning on doing a bunch of demos and wants to use Abbot for videos / demos. He's going to make some demos that shows how easy it is to use NLUDB to create Q&A systems in Abbot.