### PR TITLE
A new world of environment patching

### DIFF
--- a/src/SkillRunner/__init__.py
+++ b/src/SkillRunner/__init__.py
@@ -1,9 +1,6 @@
-import sys
 import logging
-import json
 import jsonpickle
-import traceback
-import os # used to block environ access
+import os 
 
 import azure.functions as func
 
@@ -56,7 +53,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     rm = ResponseManager()
 
     if req.method == "GET":
-        rm.add("Ok! Running Abbot Python Runner v0.5.1.")
+        rm.add("Ok! Running Abbot Python Runner v0.6.0.")
 
     try:
         deny_os_modules()

--- a/src/SkillRunner/bot/apiclient.py
+++ b/src/SkillRunner/bot/apiclient.py
@@ -1,4 +1,3 @@
-import os
 import json
 import requests
 import logging
@@ -60,7 +59,7 @@ class ApiClient(object):
             result.raise_for_status()
             return result.json()
         except Exception as e:
-            logging.error("There was an error POSTing ({})".format(e))
+            logging.error("There was an error POSTing to {}".format(uri))
             logging.error(e)
 
 

--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -1,10 +1,8 @@
 import os
 import json
-import sys
 import jsonpickle
 import requests
 import logging
-import traceback
 from unittest.mock import patch
 
 # Imports solely for use in user skill
@@ -72,16 +70,6 @@ class Mention(object):
     def __str__(self):
         return "<@{}>".format(self.user_name)
 
-class FakeOS(object):
-    """
-    Used to pass into the skill runner. 
-    Every method call returns None, but lets libraries that
-    rely on the existence of the `os` module continue running.
-    """
-    def __getattr__(self, name):
-        def method(*args):
-            return None
-
 
 class Bot(object):
     """
@@ -103,7 +91,7 @@ class Bot(object):
     :var skill_url: The URL to the edit screen of the skill being run.
     """
     def __init__(self, req, api_token):
-        self.reply_api_uri = os.environ.get('AbbotReplyApiUrl', 'https://ab.bot/api/reply')
+        self.reply_api_uri = os.environ.get('AbbotReplyApiUrl', 'https://ab.bot/api/reply') #TODO: change failure mode back to localhost.
         skillInfo = req.get('SkillInfo')
         runnerInfo = req.get('RunnerInfo')
 
@@ -153,9 +141,8 @@ class Bot(object):
             script_locals = { "bot": self, "args": self.args }
             out = None
             
-            # Remove any object from os that hasn't been explicity whitelisted.
             with patch.dict("os.environ", {}):
-                # Run the code
+                # Clear os.environ, then run the code
                 os.environ.clear()
                 exec(self.code, script_locals, script_locals)
 

--- a/src/SkillRunner/bot/secrets.py
+++ b/src/SkillRunner/bot/secrets.py
@@ -1,7 +1,5 @@
 import os
 import logging
-import requests
-import json
 
 from . import apiclient
 
@@ -14,7 +12,7 @@ class Secrets(object):
     def __init__(self, skill_id, user_id, api_token, timestamp):
         self.skill_id = skill_id
         self.user_id = user_id
-        self.request_uri = os.environ.get('SkillApiBaseUriFormatString', 'https://ab.bot/api/skills/{0}') + '/secret?key={1}'
+        self.request_uri = os.environ.get('SkillApiBaseUriFormatString', 'https://ab.bot/api/skills/{0}') + '/secret?key={1}' # TODO: replace failure mode with localhost
         if self.request_uri.startswith("https://localhost:4979"):
             logging.warn("SkillApiBaseUriFormatString appears to be blank. Using localhost as a fallback.")
         self.api_client = apiclient.ApiClient(self.request_uri, user_id, api_token, timestamp)

--- a/src/SkillRunner/bot/storage.py
+++ b/src/SkillRunner/bot/storage.py
@@ -1,6 +1,5 @@
 import os
 import json
-import requests
 import logging
 
 from . import apiclient

--- a/src/SkillRunner/bot/utils.py
+++ b/src/SkillRunner/bot/utils.py
@@ -1,7 +1,5 @@
 import os
-import json
 import requests
-import logging
 
 from . import apiclient
 


### PR DESCRIPTION
Realized that using a context manager could help resolve the issues cleaning and restoring `os.environ`... then discovered that there's a context manager that can do it [built into Python already](https://docs.python.org/3/library/unittest.mock.html)!

Also removed a bunch of dead imports, and denied risky `os` modules for the entire runner instead of trying to wipe them just for the execution context (it's stuff the runner shouldn't be trying to do anyways). 