### PR TITLE
Tokenized arguments with richer user info

### DIFF
--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -296,7 +296,7 @@ class Bot(object):
 
     def load_mention(self, mention):
         location_arg = mention.get('Location')
-        timezone_arg = mention.Get('TimeZone')
+        timezone_arg = mention.get('TimeZone')
         location = self.load_location(location_arg) if location_arg is not None else None
         timezone = self.load_timezone(timezone_arg) if timezone_arg is not None else None
         # Special case for PlatformUser mentions


### PR DESCRIPTION
This adds support for `bot.tokenized_arguments` to the Python skill runner. The reason this is important is that the tokenized arguments may include `MentionArgument` instances.

This also buffs the `Mention` class with support for `Location` and `TimeZone`. This allows Python skill authors to get access to mentioned user's location and timezone. Prior to this change, that information was not available to users.

__IMPORTANT__: This PR depends on some changes to the `SkillRunnerClient`. Those need to be deployed first before this is.
