### PR TITLE
Initialize internal fields in TriggerResponse

### DIFF
--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -64,6 +64,8 @@ class TriggerResponse(object):
     """
     def __init__(self):
         self.headers = {}
+        self._content = None
+        self._raw_content = None
 
     @property
     def content(self):


### PR DESCRIPTION
This will prevent AttributeErrors from being raised if code tries to read these properties before they're set. Fixes #31.