### PR TITLE
Change Bot.Room from a string to a Room instance

### DIFF
--- a/src/SkillRunner/__init__.py
+++ b/src/SkillRunner/__init__.py
@@ -54,7 +54,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     rm = ResponseManager()
 
     if req.method == "GET":
-        rm.add("Ok! Running Abbot Python Runner v0.8.0.")
+        rm.add("Ok! Running Abbot Python Runner v0.9.0.")
 
     try:
         deny_os_modules()

--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -22,6 +22,22 @@ from . import exceptions
 from . import apiclient
 from types import SimpleNamespace
 
+class Room(object):
+    """
+    A room is a place where people can chat.
+
+    :var id: The room ID.
+    :var name: The room name.
+    """
+    def __init__(self, room_id, room_name):
+        self.id = room_id
+        self.name = room_name
+        self.cache_key = room_id if room_id else room_name
+
+    def __str__(self):
+        return self.name
+
+
 class TriggerEvent(object):
     """
     A request triggered by an external event.
@@ -282,7 +298,7 @@ class Bot(object):
         self.arguments = self.args
         self.platform_id = skillInfo.get('PlatformId')
         self.platform_type = skillInfo.get('PlatformType')
-        self.room = skillInfo.get('Room')
+        self.room = Room(skillInfo.get('RoomId'), skillInfo.get('Room'))
         self.skill_name = skillInfo.get('SkillName')
         
         self.from_user = self.load_mention(skillInfo.get('From'))


### PR DESCRIPTION
Prior to this change, Bot.Room was a string containing the name of the room.
However, skill authors are going to want the room Id for upcoming new APIs that
allow creating, archiving, and inviting users to a room.

Related to https://github.com/aseriousbiz/abbot/pull/1495