### PR TITLE
Use the correct AbbotApiBaseUrl for production

### DIFF
--- a/docker/abbot-skills-python.Dockerfile
+++ b/docker/abbot-skills-python.Dockerfile
@@ -13,7 +13,7 @@ ENV \
     DOTNET_NOLOGO=true \
     FUNCTIONS_EXTENSION_VERSION=~3 \
     ASPNETCORE_URLS=http://+:8080 \
-    AbbotApiBaseUrl=http://host.docker.internal:4978/api
+    AbbotApiBaseUrl=https://ab.bot/api
 
 EXPOSE 8080
 COPY --from=build ["./output", "/home/site/wwwroot"]


### PR DESCRIPTION
Deployed docker images are trying to use the incorrect AbbotApiBaseUrl, this corrects that.