### PR TITLE
try getting corpora on first run

### DIFF
--- a/src/SkillRunner/__init__.py
+++ b/src/SkillRunner/__init__.py
@@ -9,6 +9,19 @@ from .bot import exceptions
 from .bot.bot import Button
 from .bot.pattern import PatternType
 
+import nltk
+
+MIN_CORPORA = [
+    'brown',  # Required for FastNPExtractor
+    'punkt',  # Required for WordTokenizer
+    'wordnet',  # Required for lemmatization
+    'averaged_perceptron_tagger',  # Required for NLTKTagger
+]
+
+# Download the minimum corpora required for NLTK / TextBlob
+for corpora in MIN_CORPORA:
+    nltk.download(corpora)
+
 class ResponseManager:
     def __init__(self):
         self.ContentType = None


### PR DESCRIPTION
textblob and nltk need the nltk corpora to work. azure functions doesn't make it easy to shell in and do this, so do it on function initialization. NLTK is smart enough to not do it twice if it already has the corpus.

This will cause the Python runner to be slow the first time it runs after NLTK is upgraded, or if Azure Functions lose their durable storage (unsure how frequently that happens right now, but it's worth a shot).