### PR TITLE
rename get_conversation (etc) to get_target

### DIFF
--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -184,7 +184,7 @@ class Bot(object):
             response (str): The response to send back to chat.
         
         Keyword Args:
-            to (Union[RoomConversation,UserConversation,ConversationAddress]): The recipient of the reply.
+            to (Union[RoomMessageTarget,UserMessageTarget,ChatAddress]): The recipient of the reply.
         """
         if direct_message:
             kwargs['to'] = self.from_user
@@ -205,7 +205,7 @@ class Bot(object):
             color (str): The color to use for the sidebar (Slack Only) in hex (ex. #3AA3E3) (optional).
         
         Keyword Args:
-            to (Union[RoomConversation,UserConversation,ConversationAddress]): The recipient of the reply.
+            to (Union[RoomMessageTarget,UserMessageTarget,ChatAddress]): The recipient of the reply.
         """
         options = MessageOptions(**kwargs)
         self._reply_client.reply_with_buttons(response, buttons, buttons_label, image_url, title, color, options)
@@ -222,7 +222,7 @@ class Bot(object):
             color (str): The color to use for the sidebar (Slack Only) in hex (ex. #3AA3E3) (optional).
         
         Keyword Args:
-            to (Union[RoomConversation,UserConversation,ConversationAddress]): The recipient of the reply.
+            to (Union[RoomMessageTarget,UserMessageTarget,ChatAddress]): The recipient of the reply.
         """
         options = MessageOptions(**kwargs)
         self._reply_client.reply_with_image(image, response, title, title_url, color, options)
@@ -236,7 +236,7 @@ class Bot(object):
             delay_in_seconds (int): The number of seconds to delay before sending the response.
         
         Keyword Args:
-            to (Union[RoomConversation,UserConversation,ConversationAddress]): The recipient of the reply.
+            to (Union[RoomMessageTarget,UserMessageTarget,ChatAddress]): The recipient of the reply.
         """
         options = MessageOptions(**kwargs)
         self._reply_client.reply_later(response, delay_in_seconds, options)

--- a/src/SkillRunner/bot/chat_address.py
+++ b/src/SkillRunner/bot/chat_address.py
@@ -1,17 +1,17 @@
 from enum import IntEnum
 from typing import Optional
 
-class ConversationType(IntEnum):
+class ChatAddressType(IntEnum):
     USER = 0
     ROOM = 1
 
-class ConversationAddress(object):
-    def __init__(self, type: ConversationType, id: str, thread_id: Optional[str] = None):
+class ChatAddress(object):
+    def __init__(self, type: ChatAddressType, id: str, thread_id: Optional[str] = None):
         self.type = type
         self.id = id
         self.thread_id = thread_id
     
-    def get_conversation_address(self):
+    def get_chat_address(self):
         return self
 
     def __eq__(self, other):

--- a/src/SkillRunner/bot/mention.py
+++ b/src/SkillRunner/bot/mention.py
@@ -1,30 +1,30 @@
 import json
 
-from .conversation_address import ConversationAddress, ConversationType
+from .chat_address import ChatAddress, ChatAddressType
 from .platform_type import PlatformType
 
-class UserConversation(object):
+class UserMessageTarget(object):
     """
-    A user conversation is a handle that can be used to send messages to that user.
+    A user message target is a handle that can be used to send messages to that user.
 
     :var id: The user ID.
     """
     def __init__(self, id):
         self.id = id
 
-    def get_conversation_address(self):
-        return ConversationAddress(ConversationType.USER, self.id)
+    def get_chat_address(self):
+        return ChatAddress(ChatAddressType.USER, self.id)
 
     def get_thread(self, thread_id: str):
         """
-        Gets a handle to the specified thread in this user's conversation with Abbot.
+        Gets a handle to the specified thread in this user's DMs with Abbot.
 
         Args:
             thread_id (str): The platform-specific thread ID.
         """
-        return ConversationAddress(ConversationType.USER, self.id, thread_id)
+        return ChatAddress(ChatAddressType.USER, self.id, thread_id)
 
-class Mention(UserConversation):
+class Mention(UserMessageTarget):
     """
     A user mention.
 

--- a/src/SkillRunner/bot/message_options.py
+++ b/src/SkillRunner/bot/message_options.py
@@ -13,7 +13,7 @@ class MessageOptions(object):
 
         # 'to', if present, should be an object that has a conversation address
         to = self.__dict__.get('to')
-        if to is not None and hasattr(to, 'get_conversation_address') and callable(to.get_conversation_address):
-            ret['to'] = to.get_conversation_address().toJSON()
+        if to is not None and hasattr(to, 'get_chat_address') and callable(to.get_chat_address):
+            ret['to'] = to.get_chat_address().toJSON()
 
         return ret

--- a/src/SkillRunner/bot/room.py
+++ b/src/SkillRunner/bot/room.py
@@ -1,28 +1,28 @@
-from .conversation_address import ConversationAddress, ConversationType
+from .chat_address import ChatAddress, ChatAddressType
 from .platform_type import PlatformType
 
-class RoomConversation(object):
+class RoomMessageTarget(object):
     """
-    A room conversation is a handle that can be used to send messages to that room.
+    A room message target is a handle that can be used to send messages to that room.
 
     :var id: The room ID.
     """
     def __init__(self, room_id):
         self.id = room_id
 
-    def get_conversation_address(self):
-        return ConversationAddress(ConversationType.ROOM, self.id)
+    def get_chat_address(self):
+        return ChatAddress(ChatAddressType.ROOM, self.id)
 
     def get_thread(self, thread_id: str):
         """
-        Gets a handle to the specified thread in this room's conversation with Abbot.
+        Gets a handle to the specified thread in this room.
 
         Args:
             thread_id (str): The platform-specific thread ID.
         """
-        return ConversationAddress(ConversationType.ROOM, self.id, thread_id)
+        return ChatAddress(ChatAddressType.ROOM, self.id, thread_id)
 
-class Room(RoomConversation):
+class Room(RoomMessageTarget):
     """
     A room is a place where people can chat.
 

--- a/src/SkillRunner/bot/rooms.py
+++ b/src/SkillRunner/bot/rooms.py
@@ -2,8 +2,8 @@ import logging
 import jsonpickle
 import urllib.parse
 
-from .conversation_address import ConversationAddress
-from .room import Room, RoomConversation
+from .chat_address import ChatAddress
+from .room import Room, RoomMessageTarget
 
 class Rooms(object):
     """
@@ -105,9 +105,9 @@ class Rooms(object):
         else:
             return Result(response.get("error"))
 
-    def get_conversation(self, room_id: str) -> RoomConversation:
+    def get_target(self, room_id: str) -> RoomMessageTarget:
         """
-        Gets a room conversation given it's platform-specific ID (for example, the Channel ID 'Cnnnnnnn' in Slack).
+        Gets a chat address, suitable for sending to with `to`, for a room, given it's platform-specific ID (for example, the Channel ID 'Cnnnnnnn' in Slack).
 
         This method does not confirm that the room exists.
         If the room does not exist, sending a message to it will fail silently.
@@ -116,9 +116,9 @@ class Rooms(object):
             id (str): The platform-specific ID of the conversation.
 
         Returns: 
-            RoomConversation: The room conversation.
+            RoomMessageTarget: The room conversation.
         """
-        return RoomConversation(room_id)
+        return RoomMessageTarget(room_id)
 
     def __room_url(self, room):
         """

--- a/src/SkillRunner/bot/users.py
+++ b/src/SkillRunner/bot/users.py
@@ -1,13 +1,12 @@
-
-from .mention import UserConversation
+from .mention import UserMessageTarget
 
 class Users(object):
     def __init__(self):
         pass
 
-    def get_conversation(self, user_id: str) -> UserConversation:
+    def get_target(self, user_id: str) -> UserMessageTarget:
         """
-        Gets a user conversation given it's platform-specific ID (for example, the User ID 'Unnnnnnn' in Slack).
+        Gets a chat address, suitable for sending to with `to`, for a user, given it's platform-specific ID (for example, the User ID 'Unnnnnnn' in Slack).
 
         This method does not confirm that the user exists.
         If the user does not exist, sending a message to it will fail silently.
@@ -16,6 +15,6 @@ class Users(object):
             id (str): The platform-specific ID of the user.
 
         Returns: 
-            UserConversation: The user conversation.
+            UserMessageTarget: The user message target.
         """
-        return UserConversation(user_id)
+        return UserMessageTarget(user_id)

--- a/src/SkillRunner/bot/utils.py
+++ b/src/SkillRunner/bot/utils.py
@@ -1,8 +1,8 @@
 from typing import Optional, Union
 
-from .mention import UserConversation
-from .room import RoomConversation
-from .conversation_address import ConversationAddress, ConversationType
+from .mention import UserMessageTarget
+from .room import RoomMessageTarget
+from .chat_address import ChatAddress, ChatAddressType
 
 import jsonpickle
 import os
@@ -87,7 +87,7 @@ class Utilities(object):
         g = Geocode(result.get("coordinate"), result.get("formattedAddress"), result.get("timeZoneId"))
         return g
 
-    def parse_slack_url(self, url: str) -> Optional[Union[RoomConversation, UserConversation, ConversationAddress]]:
+    def parse_slack_url(self, url: str) -> Optional[Union[RoomMessageTarget, UserMessageTarget, ChatAddress]]:
         """
         Attempts to parse a Slack URL into a chat conversation that can be used to send messages.
 
@@ -95,7 +95,7 @@ class Utilities(object):
             url (str): The URL to parse
 
         Returns:
-            Optional[Union[RoomConversation, UserConversation, ConversationAddress]] If successful, a chat conversation that can be used to send messages. Otherwise, `None`.
+            Optional[Union[RoomMessageTarget, UserMessageTarget, ChatAddress]] If successful, a chat conversation that can be used to send messages. Otherwise, `None`.
         """
 
         m = re.match(Utilities.__slack_url_regex, url, re.IGNORECASE)
@@ -107,7 +107,7 @@ class Utilities(object):
         if not roomOrUser or len(roomOrUser) < 1:
             return None
         
-        baseConvo = RoomConversation(roomOrUser) if roomOrUser[0] == 'C' else UserConversation(roomOrUser)
+        baseConvo = RoomMessageTarget(roomOrUser) if roomOrUser[0] == 'C' else UserMessageTarget(roomOrUser)
 
         if threadTs is not None:
             return baseConvo.get_thread(threadTs)

--- a/src/tests/test_bot_replies.py
+++ b/src/tests/test_bot_replies.py
@@ -7,7 +7,7 @@ from responses import matchers
 
 from SkillRunner.bot.bot import Bot
 from SkillRunner.bot.button import Button
-from SkillRunner.bot.conversation_address import ConversationType
+from SkillRunner.bot.chat_address import ChatAddressType
 from SkillRunner.bot.mention import TimeZone, Mention
 from SkillRunner.bot.room import Room
 
@@ -44,7 +44,7 @@ class BotTest(unittest.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertReplyCall(responses.calls[0], message="Hello, World!", options={
-            "to": { "Type": ConversationType.USER.value, "Id": TEST_FROM_USER }
+            "to": { "Type": ChatAddressType.USER.value, "Id": TEST_FROM_USER }
         })
 
     @responses.activate
@@ -55,7 +55,7 @@ class BotTest(unittest.TestCase):
         bot.reply("Hello, World!", to=TEST_SEND_USER)
         self.assertEqual(1, len(responses.calls))
         self.assertReplyCall(responses.calls[0], message="Hello, World!", options={
-            "to": { "Type": ConversationType.USER.value, "Id": TEST_SEND_USER.id }
+            "to": { "Type": ChatAddressType.USER.value, "Id": TEST_SEND_USER.id }
         })
 
     @responses.activate
@@ -66,7 +66,7 @@ class BotTest(unittest.TestCase):
         bot.reply("Hello, World!", to=TEST_SEND_USER.get_thread("1234.5678"))
         self.assertEqual(1, len(responses.calls))
         self.assertReplyCall(responses.calls[0], message="Hello, World!", options={
-            "to": { "Type": ConversationType.USER.value, "Id": TEST_SEND_USER.id, "ThreadId": "1234.5678" }
+            "to": { "Type": ChatAddressType.USER.value, "Id": TEST_SEND_USER.id, "ThreadId": "1234.5678" }
         })
 
     @responses.activate
@@ -78,7 +78,7 @@ class BotTest(unittest.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertReplyCall(responses.calls[0], message="Hello, World!", options={
-            "to": { "Type": ConversationType.ROOM.value, "Id": TEST_SEND_ROOM.id }
+            "to": { "Type": ChatAddressType.ROOM.value, "Id": TEST_SEND_ROOM.id }
         })
 
     @responses.activate
@@ -90,7 +90,7 @@ class BotTest(unittest.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertReplyCall(responses.calls[0], message="Hello, World!", options={
-            "to": { "Type": ConversationType.ROOM.value, "Id": TEST_ROOM.id, "ThreadId": TEST_MESSAGE_ID }
+            "to": { "Type": ChatAddressType.ROOM.value, "Id": TEST_ROOM.id, "ThreadId": TEST_MESSAGE_ID }
         })
 
     @responses.activate
@@ -102,7 +102,7 @@ class BotTest(unittest.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertReplyCall(responses.calls[0], message="Hello, World!", options={
-            "to": { "Type": ConversationType.ROOM.value, "Id": TEST_SEND_ROOM.id, "ThreadId": "1234.5678" }
+            "to": { "Type": ChatAddressType.ROOM.value, "Id": TEST_SEND_ROOM.id, "ThreadId": "1234.5678" }
         })
 
     @responses.activate
@@ -110,12 +110,12 @@ class BotTest(unittest.TestCase):
         self.mockReply()
 
         bot = self.create_test_bot()
-        room = bot.rooms.get_conversation("C1234")
+        room = bot.rooms.get_target("C1234")
         bot.reply("Hello, World!", to=room.get_thread("1234.5678"))
 
         self.assertEqual(1, len(responses.calls))
         self.assertReplyCall(responses.calls[0], message="Hello, World!", options={
-            "to": { "Type": ConversationType.ROOM.value, "Id": "C1234", "ThreadId": "1234.5678" }
+            "to": { "Type": ChatAddressType.ROOM.value, "Id": "C1234", "ThreadId": "1234.5678" }
         })
 
     @responses.activate
@@ -123,12 +123,12 @@ class BotTest(unittest.TestCase):
         self.mockReply()
 
         bot = self.create_test_bot()
-        user = bot.users.get_conversation("U1234")
+        user = bot.users.get_target("U1234")
         bot.reply("Hello, World!", to=user.get_thread("1234.5678"))
 
         self.assertEqual(1, len(responses.calls))
         self.assertReplyCall(responses.calls[0], message="Hello, World!", options={
-            "to": { "Type": ConversationType.USER.value, "Id": "U1234", "ThreadId": "1234.5678" }
+            "to": { "Type": ChatAddressType.USER.value, "Id": "U1234", "ThreadId": "1234.5678" }
         })
 
     @responses.activate
@@ -177,7 +177,7 @@ class BotTest(unittest.TestCase):
                 "Color": "#BEEFCAFE"
             }
         ], options={
-            "to": { "Type": ConversationType.USER.value, "Id": TEST_SEND_USER.id }
+            "to": { "Type": ChatAddressType.USER.value, "Id": TEST_SEND_USER.id }
         })
 
     @responses.activate
@@ -224,7 +224,7 @@ class BotTest(unittest.TestCase):
                 "Color": "#BEEFCAFE"
             }
         ], options={
-            "to": { "Type": ConversationType.ROOM.value, "Id": TEST_SEND_ROOM.id }
+            "to": { "Type": ChatAddressType.ROOM.value, "Id": TEST_SEND_ROOM.id }
         })
 
     

--- a/src/tests/test_conversation_address.py
+++ b/src/tests/test_conversation_address.py
@@ -1,22 +1,22 @@
 import json
 import unittest
 
-from SkillRunner.bot.conversation_address import ConversationAddress, ConversationType
+from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
 
-class ConversationAddressTest(unittest.TestCase):
+class ChatAddressTest(unittest.TestCase):
     def test_toJSON(self):
-        addr = ConversationAddress(ConversationType.USER, "U1234")
+        addr = ChatAddress(ChatAddressType.USER, "U1234")
         j = json.dumps(addr.toJSON())
         self.assertEqual(j, '{"Type": 0, "Id": "U1234"}')
     
     def test_toJSON_thread_id(self):
-        addr = ConversationAddress(ConversationType.USER, "U1234", "123.456")
+        addr = ChatAddress(ChatAddressType.USER, "U1234", "123.456")
         j = json.dumps(addr.toJSON())
         self.assertEqual(j, '{"Type": 0, "Id": "U1234", "ThreadId": "123.456"}')
     
-    def test_get_conversation_address_returns_self(self):
-        addr = ConversationAddress(ConversationType.USER, "U1234")
-        self.assertEqual(addr, addr.get_conversation_address())
+    def test_get_chat_address_returns_self(self):
+        addr = ChatAddress(ChatAddressType.USER, "U1234")
+        self.assertEqual(addr, addr.get_chat_address())
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/tests/test_mention.py
+++ b/src/tests/test_mention.py
@@ -1,20 +1,20 @@
 import unittest
 
 from SkillRunner.bot.mention import Mention, TimeZone
-from SkillRunner.bot.conversation_address import ConversationAddress, ConversationType
+from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
 
 TEST_SEND_USER = Mention(1, "cloud", "Cloud Strife", "cstrife@ava.lanche", "Midgar", TimeZone("MST"))
 
 class MentionTest(unittest.TestCase):
-    def test_get_conversation_address(self):
+    def test_get_chat_address(self):
         self.assertEqual(
-            ConversationAddress(ConversationType.USER, TEST_SEND_USER.id),
-            TEST_SEND_USER.get_conversation_address()
+            ChatAddress(ChatAddressType.USER, TEST_SEND_USER.id),
+            TEST_SEND_USER.get_chat_address()
         )
 
     def test_get_thread(self):
         self.assertEqual(
-            ConversationAddress(ConversationType.USER, TEST_SEND_USER.id, "1234.5678"),
+            ChatAddress(ChatAddressType.USER, TEST_SEND_USER.id, "1234.5678"),
             TEST_SEND_USER.get_thread("1234.5678")
         )
 

--- a/src/tests/test_room.py
+++ b/src/tests/test_room.py
@@ -1,20 +1,20 @@
 import unittest
 
-from SkillRunner.bot.conversation_address import ConversationAddress, ConversationType
+from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
 from SkillRunner.bot.room import Room
 
 TEST_SEND_ROOM = Room(1, "#midgar")
 
 class RoomTest(unittest.TestCase):
-    def test_get_conversation_address(self):
+    def test_get_chat_address(self):
         self.assertEqual(
-            ConversationAddress(ConversationType.ROOM, TEST_SEND_ROOM.id),
-            TEST_SEND_ROOM.get_conversation_address()
+            ChatAddress(ChatAddressType.ROOM, TEST_SEND_ROOM.id),
+            TEST_SEND_ROOM.get_chat_address()
         )
 
     def test_get_thread(self):
         self.assertEqual(
-            ConversationAddress(ConversationType.ROOM, TEST_SEND_ROOM.id, "1234.5678"),
+            ChatAddress(ChatAddressType.ROOM, TEST_SEND_ROOM.id, "1234.5678"),
             TEST_SEND_ROOM.get_thread("1234.5678")
         )
 

--- a/src/tests/test_rooms.py
+++ b/src/tests/test_rooms.py
@@ -3,19 +3,19 @@ import unittest
 from SkillRunner.bot.platform_type import PlatformType
 from SkillRunner.bot.rooms import Rooms
 from SkillRunner.bot.apiclient import ApiClient
-from SkillRunner.bot.conversation_address import ConversationAddress, ConversationType
+from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
 
 class RoomsTest(unittest.TestCase):
-    def test_get_conversation(self):
+    def test_get_target(self):
         rooms = Rooms(ApiClient(42, None, None, None, None), PlatformType.UNIT_TEST)
-        room = rooms.get_conversation("C1234")
+        room = rooms.get_target("C1234")
         self.assertEqual("C1234", room.id)
         self.assertEqual(
-            ConversationAddress(ConversationType.ROOM, "C1234"),
-            room.get_conversation_address()
+            ChatAddress(ChatAddressType.ROOM, "C1234"),
+            room.get_chat_address()
         )
         self.assertEqual(
-            ConversationAddress(ConversationType.ROOM, "C1234", "1234.5678"),
+            ChatAddress(ChatAddressType.ROOM, "C1234", "1234.5678"),
             room.get_thread("1234.5678")
         )
 

--- a/src/tests/test_users.py
+++ b/src/tests/test_users.py
@@ -3,19 +3,19 @@ import unittest
 from SkillRunner.bot.platform_type import PlatformType
 from SkillRunner.bot.users import Users
 from SkillRunner.bot.apiclient import ApiClient
-from SkillRunner.bot.conversation_address import ConversationAddress, ConversationType
+from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
 
 class RoomsTest(unittest.TestCase):
-    def test_get_conversation(self):
+    def test_get_target(self):
         users = Users()
-        user = users.get_conversation("U1234")
+        user = users.get_target("U1234")
         self.assertEqual("U1234", user.id)
         self.assertEqual(
-            ConversationAddress(ConversationType.USER, "U1234"),
-            user.get_conversation_address()
+            ChatAddress(ChatAddressType.USER, "U1234"),
+            user.get_chat_address()
         )
         self.assertEqual(
-            ConversationAddress(ConversationType.USER, "U1234", "1234.5678"),
+            ChatAddress(ChatAddressType.USER, "U1234", "1234.5678"),
             user.get_thread("1234.5678")
         )
 

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -3,33 +3,33 @@ import unittest
 from typing import Optional
 from parameterized import parameterized
 
-from SkillRunner.bot.conversation_address import ConversationAddress, ConversationType
+from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
 from SkillRunner.bot.utils import Utilities
 
 class UtilitiesTest(unittest.TestCase):
     @parameterized.expand([
         ("message_in_thread",
             "https://aseriousbiz.slack.com/archives/C012ZJGPYTF/p1639006342178800?thread_ts=1639006311.178500&cid=C012ZJGPYTF",
-            ConversationType.ROOM, "C012ZJGPYTF", "1639006311.178500"),
+            ChatAddressType.ROOM, "C012ZJGPYTF", "1639006311.178500"),
         ("message", 
             "https://aseriousbiz.slack.com/archives/C012ZJGPYTF/p1639006311178500",
-            ConversationType.ROOM, "C012ZJGPYTF", "1639006311.178500"),
+            ChatAddressType.ROOM, "C012ZJGPYTF", "1639006311.178500"),
         ("channel",
             "https://aseriousbiz.slack.com/archives/C012ZJGPYTF",
-            ConversationType.ROOM, "C012ZJGPYTF", None),
+            ChatAddressType.ROOM, "C012ZJGPYTF", None),
         ("dm_convo",
             "https://aseriousbiz.slack.com/archives/D02LV16PBE3",
-            ConversationType.USER, "D02LV16PBE3", None),
+            ChatAddressType.USER, "D02LV16PBE3", None),
         ("user",
             "https://aseriousbiz.slack.com/team/U02EMN2AYGH",
-            ConversationType.USER, "U02EMN2AYGH", None),
+            ChatAddressType.USER, "U02EMN2AYGH", None),
     ])
-    def test_parse_slack_url(self, name: str, url: str, conv_type: ConversationType, id: str, thread_id: Optional[str]):
+    def test_parse_slack_url(self, name: str, url: str, conv_type: ChatAddressType, id: str, thread_id: Optional[str]):
         utils = Utilities(None)
         result = utils.parse_slack_url(url)
         self.assertIsNotNone(result)
 
-        addr = result.get_conversation_address()
+        addr = result.get_chat_address()
         self.assertEqual(conv_type, addr.type)
         self.assertEqual(id, addr.id)
         self.assertEqual(thread_id, addr.thread_id)


### PR DESCRIPTION
Part of the rename to remove "conversation" from our API surface. See https://github.com/aseriousbiz/abbot/pull/1765 for more details.