### PR TITLE
fix busted environment detection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,10 @@
       "request": "launch",
       "program": "${file}",
       "purpose": ["debug-test"],
-      "cwd": "${workspaceFolder}/src"
+      "cwd": "${workspaceFolder}/src",
+      "env": {
+        "ABBOT_ENV": "test"
+      }
     }
   ]
 }

--- a/script/cibuild
+++ b/script/cibuild
@@ -23,7 +23,7 @@ echo "*** Installing requirements ***"
 python3 -m pip install -r requirements.dev.txt
 
 echo "*** Running tests ***"
-python3 -m unittest discover -s "tests"
+ABBOT_ENV=test python3 -m unittest discover -s "tests"
 
 echo "*** Installing requirements for deployment ***"
 python3 -m pip install -r requirements.txt --target="./.python_packages/lib/site-packages"

--- a/script/test
+++ b/script/test
@@ -16,4 +16,4 @@ cd "$ROOTDIR/src"
 
 source "../.venv/bin/activate"
 
-python3 -m unittest discover -s "tests" "$@"
+ABBOT_ENV=test python3 -m unittest discover -s "tests" "$@"

--- a/src/SkillRunner/bot/utils.py
+++ b/src/SkillRunner/bot/utils.py
@@ -30,8 +30,6 @@ class Environment(object):
     def __detect_env():
         if os.environ.get('ABBOT_ENV') is not None:
             return os.environ.get('ABBOT_ENV')
-        if 'unittest' in sys.modules.keys():
-            return Environment.TEST
         return Environment.PROD
 
 


### PR DESCRIPTION
This was causing 404 errors in the brain controller to raise exceptions. The logic to detect running in a test was bad and triggered in prod :(.

Longer term fix might be to have this code intentionally avoid raising on 404? It's currently raising, then getting logged and suppressed, causing the function to return `None` somewhat "accidentally".

This should help with aseriousbiz/abbot#1776