### PR TITLE
flow conversation object through to bot

### DIFF
--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -37,7 +37,7 @@ from .button import Button
 from .arguments import Argument, MentionArgument, Arguments, RoomArgument
 from types import SimpleNamespace
 from .message_options import MessageOptions
-
+from .conversations import Conversation
 
 class Bot(object):
     """
@@ -75,6 +75,7 @@ class Bot(object):
     :var is_chat: Whether or not the skill was invoked as a chat message.
     :var request: The request that triggered the skill, if any.
     :var response: The response that will be sent to the sender of the HTTP request, if any.
+    :var conversation: The conversation this skill was invoked within, if any.
     """
     def __init__(self, req, api_token, trace_parent=None):
         self.responses = []
@@ -122,6 +123,7 @@ class Bot(object):
         self.mentions = Mention.load_mentions(skillInfo.get('Mentions'))
         args_json = skillInfo.get('TokenizedArguments', [])
         self.tokenized_arguments = Arguments.from_json(args_json, self.arguments, self.platform_type)
+        self.conversation = Conversation.from_json(skillInfo.get('Conversation'), self.platform_type)
 
         self.is_interaction = skillInfo.get('IsInteraction')
         self.is_request = skillInfo.get('IsRequest')

--- a/src/SkillRunner/bot/conversations.py
+++ b/src/SkillRunner/bot/conversations.py
@@ -1,0 +1,55 @@
+from .chat_address import ChatAddress, ChatAddressType
+from .mention import Mention
+from .room import Room
+
+import json
+
+import dateutil
+
+class Conversation(object):
+    def __init__(self, id, first_message_id, title, room, started_by, created, last_message_posted_on, members):
+        self.id = id
+        self.__first_message_id = first_message_id
+        self.title = title
+        self.room = room
+        self.started_by = started_by
+        self.created = created
+        self.last_message_posted_on = last_message_posted_on
+        self.members = members
+
+    @classmethod
+    def from_json(cls, conversation_json, platform_type=None):
+        if conversation_json is None:
+            return None
+        room_arg = conversation_json.get('Room')
+        room = Room.from_arg_json(room_arg, platform_type) if room_arg is not None else None
+
+        started_by_arg = conversation_json.get('StartedBy')
+        started_by = Mention.from_json(started_by_arg, platform_type) if started_by_arg is not None else None
+
+        created_arg = conversation_json.get('Created')
+        created = dateutil.parser.isoparse(created_arg) if created_arg is not None else None
+        lmpo_arg = conversation_json.get('LastMessagePostedOn')
+        lmpo = dateutil.parser.isoparse(lmpo_arg) if lmpo_arg is not None else None
+
+        members_arg = conversation_json.get('Members')
+        members = [
+            Mention.from_json(x, platform_type) for x in members_arg
+        ] if members_arg is not None else None
+
+        return cls(
+            conversation_json.get('Id'),
+            conversation_json.get('FirstMessageId'),
+            conversation_json.get('Title'),
+            room,
+            started_by,
+            created,
+            lmpo,
+            members)
+
+    def get_chat_address(self):
+        return ChatAddress(ChatAddressType.ROOM, self.room.id, self.__first_message_id)
+
+    def toJSON(self):
+        return json.dumps(self, default=lambda o: o.__dict__, 
+            sort_keys=True, indent=4)

--- a/src/SkillRunner/bot/mention.py
+++ b/src/SkillRunner/bot/mention.py
@@ -45,6 +45,16 @@ class Mention(UserMessageTarget):
         self.timezone = timezone
         self.__platform_type = platform_type
 
+    def __eq__(self, other):
+        return isinstance(other, Mention) and \
+            self.id == other.id and \
+            self.user_name == other.user_name and \
+            self.name == other.name and \
+            self.email == other.email and \
+            self.location == other.location and \
+            self.timezone == other.timezone and \
+            self.__platform_type == other.__platform_type
+
     @staticmethod
     def load_mentions(mentions_json, platform_type=None):
         if mentions_json is None:
@@ -75,7 +85,7 @@ class Mention(UserMessageTarget):
              platform_type)
 
     def toJSON(self):
-        return json.dumps(self, default=lambda o: o.__dict__, 
+        return json.dumps(self, default=lambda o: o.__dict__,
             sort_keys=True, indent=4)
 
     def __repr__(self):
@@ -97,6 +107,11 @@ class Coordinate(object):
         self.latitude = latitude
         self.longitude = longitude
 
+    def __eq__(self, other):
+        return isinstance(other, Coordinate) and \
+            self.latitude == other.latitude and \
+            self.longitude == other.longitude
+
     @classmethod
     def from_json(cls, coordinate_json):
         if coordinate_json is None:
@@ -117,6 +132,11 @@ class Location(object):
     def __init__(self, coordinate, formatted_address):
         self.coordinate = coordinate
         self.formatted_address = formatted_address
+
+    def __eq__(self, other):
+        return isinstance(other, Location) and \
+            self.coordinate == other.coordinate and \
+            self.formatted_address == other.formatted_address
 
     @classmethod
     def from_json(cls, location_json):
@@ -142,6 +162,12 @@ class TimeZone(object):
         self.id = id
         self.min_offset = min_offset
         self.max_offset = max_offset
+
+    def __eq__(self, other):
+        return isinstance(other, TimeZone) and \
+            self.id == other.id and \
+            self.min_offset == other.min_offset and \
+            self.max_offset == other.max_offset
 
     @classmethod
     def from_json(cls, tz_json):

--- a/src/SkillRunner/bot/room.py
+++ b/src/SkillRunner/bot/room.py
@@ -37,6 +37,16 @@ class Room(RoomMessageTarget):
         self.topic = topic
         self.purpose = purpose
 
+    def __eq__(self, other):
+        return isinstance(other, Room) and \
+            self.id == other.id and \
+            self.name == other.name and \
+            self.cache_key == other.cache_key and \
+            self._platform_type == other._platform_type and \
+            self.topic == other.topic and \
+            self.purpose == other.purpose
+
+
     @classmethod
     def from_json(cls, room_json, platform_type=None):
         platform_type = platform_type if platform_type else PlatformType(room_json.get('PlatformType'))

--- a/src/tests/test_bot_init.py
+++ b/src/tests/test_bot_init.py
@@ -1,0 +1,70 @@
+import unittest
+
+from SkillRunner.bot.platform_type import PlatformType
+from SkillRunner.bot.bot import Bot
+from SkillRunner.bot.mention import Mention, TimeZone
+from SkillRunner.bot.room import Room
+
+TEST_SKILL_ID = 42
+TEST_FROM_USER = "U314"
+TEST_MESSAGE_ID = "9999.1111"
+TEST_ROOM = Room("C111", "#gaia")
+SKILLS_API_BASE = f"https://localhost:4979/api/skills/{TEST_SKILL_ID}"
+TEST_CONV_REFERENCE = {
+    "Conversation": {
+        "Id": "test_conversation_id"
+    }
+}
+TEST_SEND_USER = Mention("U777", "cloud", "Cloud Strife", "cstrife@ava.lanche", "Midgar", TimeZone("MST"))
+TEST_SEND_ROOM = Room("C777", "#midgar")
+
+
+class BotRepliesTest(unittest.TestCase):
+    def test_read_conversation_from_SkillInfo(self):
+        bot = self.create_test_bot({
+            "SkillInfo": {
+                "Conversation": {
+                    "Id": "42"
+                }
+            }
+        })
+        self.assertEqual("42", bot.conversation.id)
+
+    def create_test_bot(self, additional_request_body = {}):
+        req = {
+            "SkillInfo": {
+                "PlatformType": PlatformType.UNIT_TEST,
+                "MessagePlatformType": PlatformType.UNIT_TEST,
+                "Bot": {
+                },
+                "From": {
+                    "Id": TEST_FROM_USER
+                },
+                "RoomId": TEST_ROOM.id,
+                "RoomName": TEST_ROOM.name,
+                "MessageId": TEST_MESSAGE_ID,
+            },
+            "RunnerInfo": {
+                "SkillId": TEST_SKILL_ID,
+                "ConversationReference": TEST_CONV_REFERENCE
+            },
+            "SignalInfo": {
+            }
+        }
+        dict_merge(req, additional_request_body)
+        return Bot(req, "test_token")
+
+def dict_merge(a, b, path=None):
+    # Good ol' Stack Overflow: https://stackoverflow.com/a/7205107
+    if path is None: path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                dict_merge(a[key], b[key], path + [str(key)])
+            elif a[key] == b[key]:
+                pass # same leaf value
+            else:
+                raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+        else:
+            a[key] = b[key]
+    return a

--- a/src/tests/test_conversations.py
+++ b/src/tests/test_conversations.py
@@ -1,0 +1,61 @@
+import unittest
+
+from datetime import datetime
+from dateutil.tz import tzutc
+from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
+
+from SkillRunner.bot.conversations import Conversation
+from SkillRunner.bot.platform_type import PlatformType
+from SkillRunner.bot.rooms import Room
+from SkillRunner.bot.mention import Mention
+
+class ConversationTest(unittest.TestCase):
+    def test_parse_json(self):
+        json = {
+            "Id": "42",
+            "FirstMessageId": "1111.2222",
+            "Title": "Mako Reactor Job",
+            "Room": {
+                "Id": "C001",
+                "Name": "avalanche-planning"
+            },
+            "StartedBy": {
+                "Id": "U001",
+                "UserName": "cloud",
+                "Name": "Cloud Strife"
+            },
+            "Created": "2022-01-01T01:02:03.000000+00:00",
+            "LastMessagePostedOn": "2022-01-02T01:02:03.000000+00:00",
+            "Members": [
+                {
+                    "Id": "U001",
+                    "UserName": "cloud",
+                    "Name": "Cloud Strife",
+                },
+                {
+                    "Id": "U002",
+                    "UserName": "barret",
+                    "Name": "Barret Wallace"
+                },
+                {
+                    "Id": "U003",
+                    "UserName": "tifa",
+                    "Name": "Tifa Lockhart"
+                },
+            ]
+        }
+        convo = Conversation.from_json(json, PlatformType.SLACK)
+
+        self.assertEqual("42", convo.id)
+        self.assertEqual("Mako Reactor Job", convo.title)
+        self.assertEqual(Room("C001", "avalanche-planning", PlatformType.SLACK), convo.room)
+        self.assertEqual(Mention("U001", "cloud", "Cloud Strife", None, None, None, PlatformType.SLACK), convo.started_by)
+        self.assertEqual(datetime(2022, 1, 1, 1, 2, 3, tzinfo=tzutc()), convo.created)
+        self.assertEqual(datetime(2022, 1, 2, 1, 2, 3, tzinfo=tzutc()), convo.last_message_posted_on)
+        self.assertEqual([
+            Mention("U001", "cloud", "Cloud Strife", None, None, None, PlatformType.SLACK),
+            Mention("U002", "barret", "Barret Wallace", None, None, None, PlatformType.SLACK),
+            Mention("U003", "tifa", "Tifa Lockhart", None, None, None, PlatformType.SLACK)
+        ], convo.members)
+
+        self.assertEqual(ChatAddress(ChatAddressType.ROOM, "C001", "1111.2222"), convo.get_chat_address())


### PR DESCRIPTION
Python runner updates to make Conversation state available to user skills

This depends on aseriousbiz/abbot#1836 .

Sample skill code:

```python
import jsonpickle

if bot.conversation is not None:
  dumped = jsonpickle.encode(bot.conversation)
  bot.reply(f"Conversation Info: \n```\n{dumped}\n```", to = bot.conversation)
else:
  bot.reply("Not in a conversation.")
```

Sample output:

<img width="602" alt="image" src="https://user-images.githubusercontent.com/7574/149424539-bf7b0bfe-6db1-4ff5-b081-87510de78eb5.png">
