### PR TITLE
add dnspython to the runner per user request

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,6 +14,7 @@ chardet==3.0.4
 charset-normalizer==2.0.9
 click==8.0.3
 cryptography==3.2
+dnspython==2.2.0
 ecdsa==0.14.1
 greenlet==1.1.0
 idna==2.10


### PR DESCRIPTION
Steve from Fly.io wanted this dependency: 

> hey folks! just playing with abbot again and wondering what i need to bribe you with to get the dnspython module available? 
> we expose a bunch of information over dns TXT records that i'd like to access