### PR TITLE
update to pull WebUrl property for Conversation

### DIFF
--- a/src/SkillRunner/bot/conversations.py
+++ b/src/SkillRunner/bot/conversations.py
@@ -7,10 +7,11 @@ import json
 import dateutil
 
 class Conversation(object):
-    def __init__(self, id, first_message_id, title, room, started_by, created, last_message_posted_on, members):
+    def __init__(self, id, first_message_id, title, web_url, room, started_by, created, last_message_posted_on, members):
         self.id = id
         self.__first_message_id = first_message_id
         self.title = title
+        self.web_url = web_url
         self.room = room
         self.started_by = started_by
         self.created = created
@@ -41,6 +42,7 @@ class Conversation(object):
             conversation_json.get('Id'),
             conversation_json.get('FirstMessageId'),
             conversation_json.get('Title'),
+            conversation_json.get('WebUrl'),
             room,
             started_by,
             created,

--- a/src/tests/test_conversations.py
+++ b/src/tests/test_conversations.py
@@ -15,6 +15,7 @@ class ConversationTest(unittest.TestCase):
             "Id": "42",
             "FirstMessageId": "1111.2222",
             "Title": "Mako Reactor Job",
+            "WebUrl": "https://ab.bot/conversations/42",
             "Room": {
                 "Id": "C001",
                 "Name": "avalanche-planning"
@@ -48,6 +49,7 @@ class ConversationTest(unittest.TestCase):
 
         self.assertEqual("42", convo.id)
         self.assertEqual("Mako Reactor Job", convo.title)
+        self.assertEqual("https://ab.bot/conversations/42", convo.web_url)
         self.assertEqual(Room("C001", "avalanche-planning", PlatformType.SLACK), convo.room)
         self.assertEqual(Mention("U001", "cloud", "Cloud Strife", None, Location(None, None, None), PlatformType.SLACK), convo.started_by)
         self.assertEqual(datetime(2022, 1, 1, 1, 2, 3, tzinfo=tzutc()), convo.created)


### PR DESCRIPTION
Expose the `WebUrl` property on Conversations to PY Skills. This is safe to deploy even if Abbot isn't sending the property yet.