### PR TITLE
Publish the intermediate build container so customers can add additional dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 src/.venv
 src/tests
+src/requirements.dev.txt

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -70,7 +70,9 @@ jobs:
     - name: Build ${{env.THETAG}}
       if: env.THETAG != ''
       run: |
+        docker build --target build -t ${{ secrets.AZURE_ACR_SERVER }}/${{ env.APP_NAME }}-build:${{ env.THETAG }} -f docker/${{ env.APP_NAME }}.Dockerfile .
         docker build -t ${{ secrets.AZURE_ACR_SERVER }}/${{ env.APP_NAME }}:${{ env.THETAG }} -f docker/${{ env.APP_NAME }}.Dockerfile .
+        docker push ${{ secrets.AZURE_ACR_SERVER }}/${{ env.APP_NAME }}-build:${{ env.THETAG }}
         docker push ${{ secrets.AZURE_ACR_SERVER }}/${{ env.APP_NAME }}:${{ env.THETAG }}
 
     - name: GitHub App token


### PR DESCRIPTION
This lets users (namely fly.io) that have access to custom runners to inject additional dependencies into their runners. 

`Dockerfile`:

```
ARG tag=latest
FROM abbotacr02.azurecr.io/abbot-skills-python-build:$tag as build
WORKDIR output
COPY requirements.txt .
RUN pip install --target=./ -r ./requirements.txt

FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7-slim
ENV \
    # Enable detection of running in a container
    DOTNET_RUNNING_IN_CONTAINER=true \
    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
    DOTNET_NOLOGO=true \
    FUNCTIONS_EXTENSION_VERSION=~3 \
    AbbotApiBaseUrl=https://ab.bot/api \
    ASPNETCORE_URLS=http://+:8080 \
    AzureWebJobsSecretStorageType=files

COPY --from=build ["./output", "/home/site/wwwroot"]
COPY ["./keys", "/azure-functions-host/Secrets"]
```
