### PR TITLE
Add the official kubernetes python client

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -35,6 +35,7 @@ isodate==0.6.1
 jmespath==0.10.0
 joblib==1.1.0
 jsonpickle==2.0.0
+kubernetes==23.6.0
 msal==1.16.0
 msal-extensions==0.3.1
 msrest==0.6.21
@@ -63,6 +64,7 @@ python-dateutil==2.8.1
 python-dotenv==0.14.0
 python-jose==3.2.0
 pytz==2020.1
+PyYAML==6.0
 regex==2021.11.2
 requests==2.25.1
 requests-oauthlib==1.3.0
@@ -76,3 +78,4 @@ textblob==0.17.1
 tqdm==4.62.3
 twilio==6.63.0
 urllib3==1.25.10
+websocket-client==1.3.2


### PR DESCRIPTION
per [user request in Discord](https://discord.com/channels/808770225457463298/974432114785275944/974432584702521364), this PR adds the [official Python client for Kubernetes](https://github.com/kubernetes-client/python). 

Nice (if not a little terrifying) devops upgrade for Abbot 😎 