### PR TITLE
Allow 'requests_oauthlib' to be imported

### DIFF
--- a/src/SkillRunner/bot/policy.py
+++ b/src/SkillRunner/bot/policy.py
@@ -172,6 +172,7 @@ allowed_modules = [
     "PyYAML",
     "regex",
     "requests",
+    "requests_oauthlib",    
     "rsa",
     "soupsieve",
     "sqlalchemy",


### PR DESCRIPTION
Seems safe enough. We already allow `requests`.