### PR TITLE
build on Python 3.9

### DIFF
--- a/.github/workflows/main_abbot.yml
+++ b/.github/workflows/main_abbot.yml
@@ -21,10 +21,10 @@ jobs:
     - name: Checkout main branch
       uses: actions/checkout@v2
 
-    - name: Setup Python 3.7 Environment
+    - name: Setup Python 3.9 Environment
       uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.9'
     
     - name: 'Run CI Build script'
       shell: bash


### PR DESCRIPTION
Our new function is running Python 3.9, but we resolve dependencies with (and thus install native modules for) Python 3.7. Native modules are not compatible across versions.