### PR TITLE
deploy to old func, with 'continue-on-error'

### DIFF
--- a/.github/workflows/main_abbot.yml
+++ b/.github/workflows/main_abbot.yml
@@ -37,3 +37,12 @@ jobs:
         package: src
         publish-profile: ${{ secrets.AZURE_PYTHON_NEW_FUNCTIONAPP_PUBLISH_PROFILE }}
       if: github.event_name != 'pull_request'
+
+    - name: 'Deploy abbot-skills-python (Backup)'
+      continue-on-error: true
+      uses: Azure/functions-action@v1
+      with:
+        app-name: abbot-skills-python
+        package: src
+        publish-profile: ${{ secrets.AZURE_PYTHON_FUNCTIONAPP_PUBLISH_PROFILE }}
+      if: github.event_name != 'pull_request'


### PR DESCRIPTION
Restore deployment to our old functions app, but with `continue-on-error`.