### PR TITLE
fix python images

### DIFF
--- a/docker/abbot-skills-python-dev-local.Dockerfile
+++ b/docker/abbot-skills-python-dev-local.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7-slim
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9-slim
 
 # required container environment
 ENV \

--- a/docker/abbot-skills-python-dev.Dockerfile
+++ b/docker/abbot-skills-python-dev.Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7-buildenv as build
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9-buildenv as build
 WORKDIR output
 COPY src/ .
 RUN pip install --target=./ -r ./requirements.txt
 
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7-slim
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9-slim
 
 # required container environment
 ENV \

--- a/docker/abbot-skills-python.Dockerfile
+++ b/docker/abbot-skills-python.Dockerfile
@@ -8,7 +8,7 @@ COPY src/requirements.txt .
 RUN pip install --target=./ -r ./requirements.txt
 COPY src/ .
 
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.7-slim
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.9-slim
 
 # Upgrade any OS packages with outstanding upgrades, to ensure we've got security fixes.
 RUN apt-get update && apt-get upgrade -qyy && rm -rf /var/lib/apt/lists/*
@@ -21,7 +21,7 @@ ENV \
     DOTNET_NOLOGO=true \
     FUNCTIONS_EXTENSION_VERSION=~3 \
     ASPNETCORE_URLS=http://+:8080 \
-    AbbotApiBaseUrl=https://ab.bot/api
+    AbbotApiBaseUrl=https://app.ab.bot/api
 
 EXPOSE 8080
 COPY --from=build ["./output", "/home/site/wwwroot"]


### PR DESCRIPTION
Two fixes for the images:

* They were building on 3.9 but running on 3.7, which breaks native dependencies. I just replaced all the references to 3.7 with 3.9
* They were using `https://ab.bot/api` as the API root. In our runners, we override that with App Settings, but the Docker images need the right URL burned in (or provided as an env var at launch time).

This fixes both issues.