### PR TITLE
allow disabling the sandbox in custom images

### DIFF
--- a/src/SkillRunner/bot/apiclient.py
+++ b/src/SkillRunner/bot/apiclient.py
@@ -25,7 +25,7 @@ class ApiClient(object):
         base_url = os.environ.get('AbbotApiBaseUrl', 'https://localhost:4979/api')
         self.base_url = f'{base_url}/skills/{skill_id}'
 
-        if self.base_url.startswith("https://localhost"):
+        if self.base_url.startswith("https://localhost") or self.base_url.startswith("https://host.docker.internal"):
             self.verify_ssl = False
         else:
             self.verify_ssl = True


### PR DESCRIPTION
We sandbox python skill code in production using [RestrictedPython](https://restrictedpython.readthedocs.io/en/latest/). This is important to protect our shared environment, but it can be disruptive and block some legitimate things like reading the names of Python classes. We _could_ improve our sandboxing to allow more of those things through (they should be safe), but I have a better idea. Custom Runners need not be sandboxed. The customer is running them in their own environment and controlling who uses then and what skills are run. There's no need to be sandboxed there.

This PR adds a new feature to the runner. If the `ABBOT_SANDBOXED` environment variable is set to `false`, we skip RestrictedPython and run the code as-is, without sandboxing. This environment variable will _not_ be set in production, and will also not be set in the default docker image, but we can tell customers to set it if they need to bypass the sandboxing.