### PR TITLE
update cryptography

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,7 +15,7 @@ cffi==1.14.2
 chardet==3.0.4
 charset-normalizer==2.0.9
 click==8.0.3
-cryptography==38.0.3
+cryptography==39.0.1
 db-dtypes==1.0.1
 dnspython==2.2.0
 ecdsa==0.14.1


### PR DESCRIPTION
Supersedes #131 

This should resolve the python build failure.