### PR TITLE
Provide more sandboxing options

### DIFF
--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -39,7 +39,7 @@ from .arguments import Argument, MentionArgument, Arguments, RoomArgument
 from types import SimpleNamespace
 from .message_options import MessageOptions
 from .conversations import Conversation
-from .policy import Policy
+from .policy import getpolicy
 
 class Bot(object):
     """
@@ -162,7 +162,8 @@ class Bot(object):
 
             out = None
 
-            policy = Policy(self.logger.getChild("Policy"))
+            policy = getpolicy(self.logger.getChild("Policy"))
+            self.logger.info(f"Running user script under {type(policy).__name__} policy.")
             policy.exec(self.code, script_locals)
 
             return self.responses

--- a/src/SkillRunner/bot/policy.py
+++ b/src/SkillRunner/bot/policy.py
@@ -6,7 +6,7 @@ def getpolicy(logger):
     policy = os.environ.get("ABBOT_SANDBOX_POLICY")
     if policy is None:
         if os.environ.get("ABBOT_SANDBOXED") == "false":
-            policy = "permissive"
+            policy = "none"
         else:
             policy = "light"
 

--- a/src/SkillRunner/bot/policy.py
+++ b/src/SkillRunner/bot/policy.py
@@ -13,7 +13,7 @@ def getpolicy(logger):
     if policy == "none":
         return NoPolicy(logger)
     elif policy == "virtualized":
-        return VirtualizedPolicyu(logger)
+        return VirtualizedPolicy(logger)
     elif policy == "restrictive":
         return RestrictivePolicy(logger)
     else:

--- a/src/SkillRunner/bot/policy.py
+++ b/src/SkillRunner/bot/policy.py
@@ -8,17 +8,17 @@ def getpolicy(logger):
         if os.environ.get("ABBOT_SANDBOXED") == "false":
             policy = "none"
         else:
-            policy = "light"
+            policy = "virtualized"
 
     if policy == "none":
         return NoPolicy(logger)
-    elif policy == "light":
-        return LightPolicy(logger)
+    elif policy == "virtualized":
+        return VirtualizedPolicyu(logger)
     elif policy == "restrictive":
         return RestrictivePolicy(logger)
     else:
         # Default to light
-        return LightPolicy(logger)
+        return VirtualizedPolicy(logger)
 
 class NoPolicy(object):
     """
@@ -32,9 +32,10 @@ class NoPolicy(object):
         # We're running outside a sandboxed environment, so go ahead and run the code directly
         exec(skill_code, locals)
 
-class LightPolicy(object):
+class VirtualizedPolicy(object):
     """
     Applies a lightly-restrictive sandboxing policy to user skill code.
+    Intended for use in environments where the runner is already isolated from the rest of the application.
     This restricts _known_ exploitable functions, but there may be unknown ways to exploit the environment.
     """
 


### PR DESCRIPTION
This expands our sandboxing options and splits them in to three profiles:

1. No Sandboxing
2. "Light" Sandboxing - Assumes you're running on a relatively-sandboxed host and only does some basic filtering of environment variables (to reduce noise rather than protect resources)
3. Restrictive Sandboxing - Our current sandboxing profile, uses RestrictedPython to severely limit what scripts can do.