### PR TITLE
set the AbbotApiBaseUrl env var by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG BUILD_BRANCH=""
+ARG BUILD_SHA=""
 ARG PYTHON_VERSION="3.9"
 FROM python:${PYTHON_VERSION}-buster
 
@@ -9,5 +11,6 @@ RUN pip install -r /app/requirements.txt
 COPY ./src /app
 
 RUN echo "${BUILD_BRANCH}\n${BUILD_SHA}" > "/app/build_info.txt"
+ENV AbbotApiBaseUrl=https://app.ab.bot/api
 
 ENTRYPOINT [ "python3", "/app/runner.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY ./src /app
 RUN echo "${BUILD_BRANCH}\n${BUILD_SHA}" > "/app/build_info.txt"
 ENV AbbotApiBaseUrl=https://app.ab.bot/api
 ENV HOST="0.0.0.0"
-ENV PORT="8080"
+ENV PORT="80"
 
 ENTRYPOINT [ "python3", "/app/runner.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN echo "${BUILD_BRANCH}\n${BUILD_SHA}" > "/app/build_info.txt"
 ENV AbbotApiBaseUrl=https://app.ab.bot/api
 ENV HOST="0.0.0.0"
 ENV PORT="80"
-
+ENV ABBOT_SANDBOX_POLICY="permissive"
 ENTRYPOINT [ "python3", "/app/runner.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,7 @@ COPY ./src /app
 
 RUN echo "${BUILD_BRANCH}\n${BUILD_SHA}" > "/app/build_info.txt"
 ENV AbbotApiBaseUrl=https://app.ab.bot/api
+ENV HOST="0.0.0.0"
+ENV PORT="8080"
 
 ENTRYPOINT [ "python3", "/app/runner.py" ]

--- a/functions.Dockerfile
+++ b/functions.Dockerfile
@@ -24,7 +24,7 @@ ENV \
     DOTNET_NOLOGO=true \
     FUNCTIONS_EXTENSION_VERSION=~3 \
     ASPNETCORE_URLS=http://+:8080 \
-    AbbotApiBaseUrl=https://ab.bot/api
+    AbbotApiBaseUrl=https://app.ab.bot/api
 
 EXPOSE 8080
 COPY --from=build ./output /home/site/wwwroot


### PR DESCRIPTION
Also sets `BUILD_BRANCH` and `BUILD_SHA` properly for the non-functions image (I think, we'll see 😆 )