### PR TITLE
Add support for bot.message

### DIFF
--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -39,6 +39,7 @@ from .arguments import Argument, MentionArgument, Arguments, RoomArgument
 from .message_options import MessageOptions
 from .conversations import Conversation
 from .policy import get_policy
+from .source_message import SourceMessage
 
 class Bot(object):
     """
@@ -100,6 +101,7 @@ class Bot(object):
         self.message_id = skillInfo.get('MessageId')
         thread_id = skillInfo.get('ThreadId') or self.message_id
         self.thread = self.room.get_thread(thread_id)
+        self.message = SourceMessage.from_json(skillInfo.get('Message'))
 
         # Clients
         api_client = ApiClient(self.skill_id, self.user_id, api_token, self.timestamp, trace_parent, self.logger.getChild("ApiClient"))

--- a/src/SkillRunner/bot/source_message.py
+++ b/src/SkillRunner/bot/source_message.py
@@ -1,0 +1,25 @@
+from .mention import Mention
+
+
+class SourceMessage(object):
+    """
+    The source message for calling a skill. Either the message that invoked the skill
+    or the message that was reacted to such as a button click or reaction.
+    """
+
+    def __init__(self, id, thread_id, text, url, author):
+        self.id = id
+        self.thread_id = thread_id
+        self.text = text
+        self.url = url
+        self.author = author
+
+    @classmethod
+    def from_json(cls, message_json):
+        """
+        Returns a SourceMessage from JSON.
+        """
+        if message_json is None:
+            return None
+        author = Mention.from_json(message_json.get('Author'))
+        return cls(message_json.get('MessageId'), message_json.get('ThreadId'), message_json.get('Text'), message_json.get('MessageUrl'), author)


### PR DESCRIPTION
This adds support to the Python skill runner to retrieve the source message via `bot.message`

Example python skill. Subscribe this to the `system:reaction:added` signal and then add a reaction to a message to see it in action.

```py
# Change the code below with the code for your skill! 
if (bot.signal_event is not None):
  in_convo = "not" if bot.conversation is None else "";
  bot.reply(f'PYTHON: {bot.from_user} added :{bot.signal_event.arguments}: reaction to <{bot.message.url}|message> from {bot.message.author} which is {in_convo} part of a conversation.')
```