### PR TITLE
add 'get_user' to 'bot.users'

### DIFF
--- a/src/SkillRunner/bot/arguments.py
+++ b/src/SkillRunner/bot/arguments.py
@@ -26,7 +26,7 @@ class Argument(object):
         original_text = arg_json.get('OriginalText')
         mentioned_arg = arg_json.get('Mentioned')
         room_arg = arg_json.get('Room')
-        mentioned = Mention.from_json(mentioned_arg, platform_type)
+        mentioned = Mention.from_json(mentioned_arg)
         return MentionArgument(value, original_text, mentioned) if mentioned \
             else RoomArgument(value, original_text, Room.from_arg_json(room_arg, platform_type)) if room_arg \
             else Argument(value, original_text)

--- a/src/SkillRunner/bot/bot.py
+++ b/src/SkillRunner/bot/bot.py
@@ -108,7 +108,7 @@ class Bot(object):
         self.brain = Brain(api_client) 
         self.secrets = Secrets(api_client)
         self.rooms = Rooms(api_client, self.platform_type)
-        self.users = Users()
+        self.users = Users(api_client)
         self.utils = Utilities(api_client)
         self._signaler = Signaler(api_client, req)
         self._reply_client = ReplyClient(api_client, self.room, thread_id, req.get('PassiveReplies'), runnerInfo.get('ConversationReference'), self.skill_id, self.responses)

--- a/src/SkillRunner/bot/conversations.py
+++ b/src/SkillRunner/bot/conversations.py
@@ -26,7 +26,7 @@ class Conversation(object):
         room = Room.from_arg_json(room_arg, platform_type) if room_arg is not None else None
 
         started_by_arg = conversation_json.get('StartedBy')
-        started_by = Mention.from_json(started_by_arg, platform_type) if started_by_arg is not None else None
+        started_by = Mention.from_json(started_by_arg) if started_by_arg is not None else None
 
         created_arg = conversation_json.get('Created')
         created = dateutil.parser.isoparse(created_arg) if created_arg is not None else None
@@ -35,7 +35,7 @@ class Conversation(object):
 
         members_arg = conversation_json.get('Members')
         members = [
-            Mention.from_json(x, platform_type) for x in members_arg
+            Mention.from_json(x) for x in members_arg
         ] if members_arg is not None else None
 
         return cls(

--- a/src/SkillRunner/bot/mention.py
+++ b/src/SkillRunner/bot/mention.py
@@ -1,21 +1,138 @@
 import json
+from typing import Optional, TypeVar
 
 from .chat_address import ChatAddress, ChatAddressType
-from .platform_type import PlatformType
+
+class Coordinate(object):
+    latitude: float
+    longitude: float
+
+    """
+    Represents a geographic coordinate.
+
+    :var latitude: The latitude. Those are the lines that are the belts of the earth.
+    :var longitude: The longitude. Those are the pin stripes of the earth.
+    """
+    def __init__(self, latitude: float, longitude: float):
+        self.latitude = latitude
+        self.longitude = longitude
+
+    def __eq__(self: 'Coordinate', other: 'Coordinate') -> bool:
+        return isinstance(other, Coordinate) and \
+            self.latitude == other.latitude and \
+            self.longitude == other.longitude
+
+    @classmethod
+    def from_json(cls: type['Coordinate'], coordinate_json: dict) -> Optional['Coordinate']:
+        if coordinate_json is None:
+            return None
+        return cls(coordinate_json.get('Latitude'), coordinate_json.get('Longitude'))
+
+    def __str__(self) -> str:
+        return "lat: {}, lon: {}".format(self.latitude, self.longitude)
+
+
+class TimeZone(object):
+    id: str
+    min_offset: Optional[float]
+    max_offset: Optional[float]
+    """
+    Information about a user's timezone
+
+    :var id: The provider's ID for the timezone. Could be IANA or BCL.
+    :var min_offset: Gets the least (most negative) offset within this time zone, over all time.
+    :var max_offset: Gets the greatest (most positive) offset within this time zone, over all time.
+    """
+    def __init__(self, id: str, min_offset: Optional[float]=None, max_offset: Optional[float]=None):
+        self.id = id
+        self.min_offset = min_offset
+        self.max_offset = max_offset
+
+    def __eq__(self: 'TimeZone', other: 'TimeZone') -> bool:
+        return isinstance(other, TimeZone) and \
+            self.id == other.id and \
+            self.min_offset == other.min_offset and \
+            self.max_offset == other.max_offset
+
+    @classmethod
+    def from_json(cls: type['TimeZone'], tz_json: dict) -> Optional['TimeZone']:
+        if tz_json is None:
+            return None
+        if isinstance(tz_json, str):
+            return cls(tz_json)
+        if isinstance(tz_json, dict):
+            return cls(tz_json.get('Id'), tz_json.get('MinOffset'), tz_json.get('MaxOffset'))
+
+        return None
+
+    def __str__(self: 'TimeZone') -> str:
+        return self.id
+
+class Location(object):
+    coordinate: Coordinate
+    formatted_address: str
+    __timezone: Optional[TimeZone]
+
+    """
+    A geo-coded location
+
+    :var coordinate: The coordinates of the location.
+    :var formatted_address: The formatted address of the location.
+    """
+    def __init__(self, coordinate: Coordinate, formatted_address: str, timezone: Optional[TimeZone]):
+        self.coordinate = coordinate
+        self.formatted_address = formatted_address
+        self.__timezone = timezone
+
+    @property
+    def timezone(self: 'Location') -> Optional[TimeZone]:
+        return self.__timezone
+    
+    @timezone.setter
+    def timezone(self: 'Location', val: Optional[TimeZone]):
+        self.__timezone = val
+
+    def __eq__(self: 'Location', other: 'Location') -> bool:
+        return isinstance(other, Location) and \
+            self.coordinate == other.coordinate and \
+            self.formatted_address == other.formatted_address and \
+            self.__timezone == other.__timezone
+
+    @classmethod
+    def from_json(cls: type['Location'], location_json: dict) -> 'Location':
+        if location_json is None:
+            return None
+        coordinate_arg = location_json.get('Coordinate')
+        coordinate = Coordinate.from_json(coordinate_arg)
+
+        timezone_arg = location_json.get('TimeZone')
+        if timezone_arg is None:
+            id = location_json.get('TimeZoneId')
+            timezone = TimeZone(id) if id is not None else None
+        else:
+            timezone = TimeZone.from_json(timezone_arg)
+
+        return cls(coordinate, location_json.get('FormattedAddress'), timezone)
+
+    def __str__(self: 'Location') -> str:
+        return "coordinate: {}, address: {}".format(self.coordinate, self.formatted_address)
+
 
 class UserMessageTarget(object):
+    id: str
+
     """
     A user message target is a handle that can be used to send messages to that user.
 
     :var id: The user ID.
     """
-    def __init__(self, id):
+    def __init__(self, id: str):
         self.id = id
 
-    def get_chat_address(self):
+    def get_chat_address(self) -> ChatAddress:
         return ChatAddress(ChatAddressType.USER, self.id)
 
-    def get_thread(self, thread_id: str):
+    def get_thread(self, thread_id: str) -> ChatAddress:
         """
         Gets a handle to the specified thread in this user's DMs with Abbot.
 
@@ -25,6 +142,12 @@ class UserMessageTarget(object):
         return ChatAddress(ChatAddressType.USER, self.id, thread_id)
 
 class Mention(UserMessageTarget):
+    id: str
+    user_name: str
+    name: str
+    email: str
+    location: Location
+
     """
     A user mention.
 
@@ -34,38 +157,35 @@ class Mention(UserMessageTarget):
     :var email: The user's email if known
     :var location: The user's location if known.
     :var timezone: The user's timezone if known
-    :var platform_type: The platform type of the user.
     """
-    def __init__(self, id, user_name, name, email, location, platform_type=None):
+    def __init__(self, id: str, user_name: str, name: str, email: str, location: Location):
         super().__init__(id)
         self.user_name = user_name
         self.name = name
         self.email = email
         self.location = location
-        self.__platform_type = platform_type
 
-    def __eq__(self, other):
+    def __eq__(self: 'Mention', other: 'Mention') -> bool:
         return isinstance(other, Mention) and \
             self.id == other.id and \
             self.user_name == other.user_name and \
             self.name == other.name and \
             self.email == other.email and \
-            self.location == other.location and \
-            self.__platform_type == other.__platform_type
+            self.location == other.location
 
     @property
-    def timezone(self):
+    def timezone(self: 'Mention') -> Optional[TimeZone]:
         return self.location.timezone if self.location is not None else None
 
     @staticmethod
-    def load_mentions(mentions_json, platform_type=None):
+    def load_mentions(mentions_json: list[dict]) -> list['Mention']:
         if mentions_json is None:
             return []
         else:
-            return [Mention.from_json(m, platform_type) for m in mentions_json]
+            return [Mention.from_json(m) for m in mentions_json]
 
     @classmethod
-    def from_json(cls, mention_json, platform_type=None):
+    def from_json(cls: type['Mention'], mention_json: dict) -> Optional['Mention']: 
         if mention_json is None:
             return None
         location_arg = mention_json.get('Location')
@@ -88,125 +208,70 @@ class Mention(UserMessageTarget):
             mention_json.get('UserName'),
             mention_json.get('Name'),
             mention_json.get('Email'),
-            location,
-            platform_type)
+            location)
 
-    def toJSON(self):
+    def toJSON(self: 'Mention') -> str:
         return json.dumps(self, default=lambda o: o.__dict__,
             sort_keys=True, indent=4)
 
-    def __repr__(self):
+    def __repr__(self: 'Mention') -> str:
         return str(self)
 
-    def __str__(self):
-        return f"<at>{self.name}</at>" if self.__platform_type == PlatformType.MS_TEAMS \
-            else f"<@{self.id}>"
+    def __str__(self: 'Mention') -> str:
+        return f"<@{self.id}>"
 
+class UserProfileField(object):
+    id: str
+    value: str
+    alt: str
 
-class Coordinate(object):
     """
-    Represents a geographic coordinate.
-
-    :var latitude: The latitude. Those are the lines that are the belts of the earth.
-    :var longitude: The longitude. Those are the pin stripes of the earth.
+    A user profile field.
     """
-    def __init__(self, latitude, longitude):
-        self.latitude = latitude
-        self.longitude = longitude
-
-    def __eq__(self, other):
-        return isinstance(other, Coordinate) and \
-            self.latitude == other.latitude and \
-            self.longitude == other.longitude
-
-    @classmethod
-    def from_json(cls, coordinate_json):
-        if coordinate_json is None:
-            return None
-        return cls(coordinate_json.get('Latitude'), coordinate_json.get('Longitude'))
-
-    def __str__(self):
-        return "lat: {}, lon: {}".format(self.latitude, self.longitude)
-
-
-class Location(object):
-    """
-    A geo-coded location
-
-    :var coordinate: The coordinates of the location.
-    :var formatted_address: The formatted address of the location.
-    """
-    def __init__(self, coordinate, formatted_address, timezone):
-        self.coordinate = coordinate
-        self.formatted_address = formatted_address
-        self.__timezone = timezone
-
-    @property
-    def timezone(self):
-        return self.__timezone
-    
-    @timezone.setter
-    def timezone(self, val):
-        self.__timezone = val
-
-    def __eq__(self, other):
-        return isinstance(other, Location) and \
-            self.coordinate == other.coordinate and \
-            self.formatted_address == other.formatted_address and \
-            self.__timezone == other.__timezone
-
-    @classmethod
-    def from_json(cls, location_json):
-        if location_json is None:
-            return None
-        coordinate_arg = location_json.get('Coordinate')
-        coordinate = Coordinate.from_json(coordinate_arg)
-
-        timezone_arg = location_json.get('TimeZone')
-        if timezone_arg is None:
-            id = location_json.get('TimeZoneId')
-            timezone = TimeZone(id) if id is not None else None
-        else:
-            timezone = TimeZone.from_json(timezone_arg)
-
-        return cls(coordinate, location_json.get('FormattedAddress'), timezone)
-
-    def __str__(self):
-        return "coordinate: {}, address: {}".format(self.coordinate, self.formatted_address)
-
-
-class TimeZone(object):
-    """
-    Information about a user's timezone
-
-    :var id: The provider's ID for the timezone. Could be IANA or BCL.
-    :var min_offset: Gets the least (most negative) offset within this time zone, over all time.
-    :var max_offset: Gets the greatest (most positive) offset within this time zone, over all time.
-    """
-    def __init__(self, id, min_offset=None, max_offset=None):
+    def __init__(self, id: str, value: str, alt: str):
         self.id = id
-        self.min_offset = min_offset
-        self.max_offset = max_offset
-
-    def __eq__(self, other):
-        return isinstance(other, TimeZone) and \
-            self.id == other.id and \
-            self.min_offset == other.min_offset and \
-            self.max_offset == other.max_offset
+        self.value = value
+        self.alt = alt
 
     @classmethod
-    def from_json(cls, tz_json):
-        if tz_json is None:
+    def from_json(cls: type['UserProfileField'], json: dict) -> Optional['UserProfileField']: 
+        if json is None:
             return None
-        if isinstance(tz_json, str):
-            return cls(tz_json)
-        if isinstance(tz_json, dict):
-            return cls(tz_json.get('Id'), tz_json.get('MinOffset'), tz_json.get('MaxOffset'))
+        id = json.get('id')
+        value = json.get('value')
+        alt = json.get('alt')
+        return cls(id, value, alt)
 
-        return None
+class UserProfile(Mention):
+    """
+    A user profile.
 
-    def __str__(self):
-        return self.id
+    :var id: The user's Id.
+    :var user_name: The user's user name.
+    :var name: The user's name.
+    :var email: The user's email if known
+    :var location: The user's location if known.
+    :var timezone: The user's timezone if known
+    """
+    def __init__(self, id: str, user_name: str, name: str, email: str, location: Location, custom_fields: dict[str, UserProfileField]):
+        super().__init__(id, user_name, name, email, location)
+        self.custom_fields = custom_fields
+
+    @classmethod
+    def from_json(cls: type['UserProfile'], json: dict) -> Optional['UserProfile']: 
+        if json is None:
+            return None
+
+        mention = Mention.from_json(json)
+        fields = json.get("customFields")
+        custom_fields = {}
+        for key in fields:
+            custom_fields[key] = UserProfileField.from_json(fields[key])
         
-    def __eq__(self, other):
-        return self.id == other.id and self.min_offset == other.min_offset and self.max_offset == other.max_offset
+        return cls(
+            mention.id,
+            mention.user_name,
+            mention.name,
+            mention.email,
+            mention.location,
+            custom_fields)

--- a/src/SkillRunner/bot/users.py
+++ b/src/SkillRunner/bot/users.py
@@ -1,8 +1,17 @@
-from .mention import UserMessageTarget
+import urllib.parse
+
+from .mention import UserMessageTarget, UserProfile
+from .apiclient import ApiClient
 
 class Users(object):
-    def __init__(self):
-        pass
+    """
+    Users API client
+    """
+
+    _api_client: ApiClient
+
+    def __init__(self, api_client: ApiClient):
+        self._api_client = api_client
 
     def get_target(self, user_id: str) -> UserMessageTarget:
         """
@@ -12,9 +21,22 @@ class Users(object):
         If the user does not exist, sending a message to it will fail silently.
 
         Args:
-            id (str): The platform-specific ID of the user.
+            user_id (str): The platform-specific ID of the user.
 
         Returns: 
             UserMessageTarget: The user message target.
         """
         return UserMessageTarget(user_id)
+    
+    def get_user(self, user_id: str) -> UserProfile:
+        """
+        Gets a user's profile, given their platform-specific ID (for example, the User ID 'Unnnnnnn' in Slack).
+
+        Args:
+            user_id (str): The platform-specific ID of the user.
+
+        Returns: 
+            UserProfile: The user profile.
+        """
+        response = self._api_client.get(f"/users/{urllib.parse.quote_plus(user_id)}")
+        return UserProfile.from_json(response)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -22,7 +22,6 @@ cryptography==39.0.1
 db-dtypes==1.0.1
 dnspython==2.2.0
 ecdsa==0.14.1
-Flask==2.2.2
 google-api-core==2.7.3
 google-auth-oauthlib==0.5.1
 google-auth==2.6.6
@@ -96,5 +95,4 @@ urllib3==1.26.5
 websocket-client==1.3.2
 wrapt==1.13.3
 setuptools==65.5.1
-    # pip-audit: subdependency fixed via Flask==2.2.2,Flask==2.2.2
 flask==2.2.5

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -96,3 +96,5 @@ urllib3==1.26.5
 websocket-client==1.3.2
 wrapt==1.13.3
 setuptools==65.5.1
+    # pip-audit: subdependency fixed via Flask==2.2.2,Flask==2.2.2
+flask==2.2.5

--- a/src/tests/test_bot_init.py
+++ b/src/tests/test_bot_init.py
@@ -2,7 +2,7 @@ import unittest
 
 from SkillRunner.bot.platform_type import PlatformType
 from SkillRunner.bot.bot import Bot
-from SkillRunner.bot.mention import Mention, TimeZone
+from SkillRunner.bot.mention import Mention, TimeZone, Location, Coordinate
 from SkillRunner.bot.room import Room
 
 TEST_SKILL_ID = 42
@@ -16,7 +16,7 @@ TEST_CONV_REFERENCE = {
     }
 }
 
-TEST_SEND_USER = Mention("U777", "cloud", "Cloud Strife", "cstrife@ava.lanche", "Midgar", TimeZone("MST"))
+TEST_SEND_USER = Mention("U777", "cloud", "Cloud Strife", "cstrife@ava.lanche", Location(Coordinate(0, 0), "Midgar", TimeZone("America/Los_Angeles")))
 TEST_SEND_ROOM = Room("C777", "#midgar")
 
 class BotInitTest(unittest.TestCase):

--- a/src/tests/test_bot_replies.py
+++ b/src/tests/test_bot_replies.py
@@ -9,7 +9,7 @@ from SkillRunner.bot.bot import Bot
 from SkillRunner.bot.platform_type import PlatformType
 from SkillRunner.bot.button import Button
 from SkillRunner.bot.chat_address import ChatAddressType
-from SkillRunner.bot.mention import TimeZone, Mention
+from SkillRunner.bot.mention import Mention, TimeZone, Location, Coordinate
 from SkillRunner.bot.room import Room
 
 TEST_SKILL_ID = 42
@@ -22,7 +22,7 @@ TEST_CONV_REFERENCE = {
         "Id": "test_conversation_id"
     }
 }
-TEST_SEND_USER = Mention("U777", "cloud", "Cloud Strife", "cstrife@ava.lanche", "Midgar", TimeZone("MST"))
+TEST_SEND_USER = Mention("U777", "cloud", "Cloud Strife", "cstrife@ava.lanche", Location(Coordinate(0, 0), "Midgar", TimeZone("America/Los_Angeles")))
 TEST_SEND_ROOM = Room("C777", "#midgar")
 
 class BotRepliesTest(unittest.TestCase):

--- a/src/tests/test_conversations.py
+++ b/src/tests/test_conversations.py
@@ -51,13 +51,13 @@ class ConversationTest(unittest.TestCase):
         self.assertEqual("Mako Reactor Job", convo.title)
         self.assertEqual("https://ab.bot/conversations/42", convo.web_url)
         self.assertEqual(Room("C001", "avalanche-planning", PlatformType.SLACK), convo.room)
-        self.assertEqual(Mention("U001", "cloud", "Cloud Strife", None, Location(None, None, None), PlatformType.SLACK), convo.started_by)
+        self.assertEqual(Mention("U001", "cloud", "Cloud Strife", None, Location(None, None, None)), convo.started_by)
         self.assertEqual(datetime(2022, 1, 1, 1, 2, 3, tzinfo=tzutc()), convo.created)
         self.assertEqual(datetime(2022, 1, 2, 1, 2, 3, tzinfo=tzutc()), convo.last_message_posted_on)
         self.assertEqual([
-            Mention("U001", "cloud", "Cloud Strife", None, Location(None, None, None), PlatformType.SLACK),
-            Mention("U002", "barret", "Barret Wallace", None, Location(None, None, None), PlatformType.SLACK),
-            Mention("U003", "tifa", "Tifa Lockhart", None, Location(None, None, None), PlatformType.SLACK)
+            Mention("U001", "cloud", "Cloud Strife", None, Location(None, None, None)),
+            Mention("U002", "barret", "Barret Wallace", None, Location(None, None, None)),
+            Mention("U003", "tifa", "Tifa Lockhart", None, Location(None, None, None))
         ], convo.members)
 
         self.assertEqual(ChatAddress(ChatAddressType.ROOM, "C001", "1111.2222"), convo.get_chat_address())

--- a/src/tests/test_mention.py
+++ b/src/tests/test_mention.py
@@ -2,10 +2,10 @@ import unittest
 
 from parameterized import parameterized
 
-from SkillRunner.bot.mention import Mention, TimeZone
+from SkillRunner.bot.mention import Mention, TimeZone, Location, Coordinate
 from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
 
-TEST_SEND_USER = Mention(1, "cloud", "Cloud Strife", "cstrife@ava.lanche", "Midgar", TimeZone("MST"))
+TEST_SEND_USER = Mention(1, "cloud", "Cloud Strife", "cstrife@ava.lanche", Location(Coordinate(0, 0), "Midgar", TimeZone("America/Los_Angeles")))
 
 class MentionTest(unittest.TestCase):
     def test_get_chat_address(self):

--- a/src/tests/test_users.py
+++ b/src/tests/test_users.py
@@ -7,7 +7,7 @@ from SkillRunner.bot.chat_address import ChatAddress, ChatAddressType
 
 class RoomsTest(unittest.TestCase):
     def test_get_target(self):
-        users = Users()
+        users = Users(ApiClient(42, None, None, None, None))
         user = users.get_target("U1234")
         self.assertEqual("U1234", user.id)
         self.assertEqual(


### PR DESCRIPTION
Matches up with https://github.com/aseriousbiz/abbot/pull/3995

Implements `bot.users.get_user` using the `/api/skills/[skillId]/users/[userId]` API on Abbot.Web

In addition:
* Removed some unnecessary PlatformTypes (since we have only Slack now)
* Removed the encryption of the Skill API token. There's no need to hide that token from skill code, and we should _assume_ skill code has that token.

Test Skill:

```python
import json

user = bot.users.get_user(bot.tokenized_arguments[0].value)
if user is None:
  bot.reply("No such user")
  
for key in user.custom_fields:
  bot.reply(f"* `{key}`: `{user.custom_fields[key].value}`")
```

Example output:

<img width="455" alt="image" src="https://user-images.githubusercontent.com/7574/236341044-a018fa36-3499-4404-a7d0-d157cc05c28a.png">
